### PR TITLE
Update drawings-gods_data-lists.ttl

### DIFF
--- a/drawings-gods_data-lists.ttl
+++ b/drawings-gods_data-lists.ttl
@@ -51,7 +51,7 @@
 	knora-base:isRootNode true ;
 	rdfs:comment "Liste de choix pour l'auteur du commentaire sur le verso"@fr ;
 	rdfs:label "Auteur du commentaire sur le verso (liste)"@fr , "Author of comment on verso (list)"@en ;
-	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-child> ,
+	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-nocomment> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-collector> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-teacher> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-unknownAdult> ,
@@ -59,11 +59,11 @@
 	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-other> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-irrelevant> .
 
-	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-child> a knora-base:ListNode ;
-		knora-base:listNodeName "child" ;
+	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-nocomment> a knora-base:ListNode ;
+		knora-base:listNodeName "nocomment" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList> ;
 		knora-base:listNodePosition 0 ;
-		rdfs:label "Enfant"@fr , "Child"@en .
+		rdfs:label "Pas de commentaire"@fr , "No comments"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-CommentAuthorList-collector> a knora-base:ListNode ;
 		knora-base:listNodeName "collector" ;
@@ -106,8 +106,7 @@
 	knora-base:isRootNode true ;
 	rdfs:comment "Liste de choix pour l'auteur de la description sur le verso"@fr ;
 	rdfs:label "Auteur de la description sur le verso (liste)"@fr , "Author of description on verso (list)"@en ;
-	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList--> ,
-	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-child> ,
+	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-child> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-collector> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-teacher> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-unknownAdult> ,
@@ -115,52 +114,46 @@
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-other> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-irrelevant> .
 
-	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList--> a knora-base:ListNode ;
-		knora-base:listNodeName "-" ;
-		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 0 ;
-		rdfs:label "-"@fr , "-"@en .
-
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-child> a knora-base:ListNode ;
 		knora-base:listNodeName "child" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 1 ;
+		knora-base:listNodePosition 0 ;
 		rdfs:label "Enfant"@fr , "Child"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-collector> a knora-base:ListNode ;
 		knora-base:listNodeName "collector" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 2 ;
+		knora-base:listNodePosition 1 ;
 		rdfs:label "Collecteur"@fr , "Collector"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-teacher> a knora-base:ListNode ;
 		knora-base:listNodeName "teacher" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 3 ;
+		knora-base:listNodePosition 2 ;
 		rdfs:label "Maître d'école"@fr , "Teacher"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-unknownAdult> a knora-base:ListNode ;
 		knora-base:listNodeName "unknownadult" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 4 ;
+		knora-base:listNodePosition 3 ;
 		rdfs:label "Adulte non-identifié"@fr , "Unknown adult"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-translator> a knora-base:ListNode ;
 		knora-base:listNodeName "translator" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 5 ;
+		knora-base:listNodePosition 4 ;
 		rdfs:label "Traducteur"@fr , "Translator"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 6 ;
+		knora-base:listNodePosition 5 ;
 		rdfs:label "Autre"@fr , "Other"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList-irrelevant> a knora-base:ListNode ;
 		knora-base:listNodeName "irrelevant" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DescriptionAuthorList> ;
-		knora-base:listNodePosition 7 ;
+		knora-base:listNodePosition 6 ;
 		rdfs:label "Non pertinent"@fr , "Irrelevant"@en .
 
 ###    GlobalLocationHList
@@ -656,7 +649,7 @@
 		knora-base:listNodeName "event" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList> ;
 		knora-base:listNodePosition 1 ;
-		rdfs:label "Evenement"@fr , "Event"@en ;
+		rdfs:label "Evénement"@fr , "Event"@en ;
 		knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList-layEvent> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList-relEvent> .
 
@@ -664,19 +657,19 @@
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList> ;
 				knora-base:listNodeName "layEvent" ;
 				knora-base:listNodePosition 0 ;
-				rdfs:label "Evenement laïque"@fr , "Lay event"@en .
+				rdfs:label "Evénement laïque"@fr , "Lay event"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList-relEvent> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList> ;
 				knora-base:listNodeName "relEvent" ;
 				knora-base:listNodePosition 1 ;
-				rdfs:label "Evenement religieux"@fr , "Religious event"@en .
+				rdfs:label "Evénement religieux"@fr , "Religious event"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList-singularCollect> a knora-base:ListNode ;
 		knora-base:listNodeName "singularCollect" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "Collect singulier"@fr , "Singular collect"@en .
+		rdfs:label "Collecte individuelle"@fr , "Individual collect"@en .
 
 ###   InstructionCodeList
 
@@ -686,7 +679,7 @@
 	rdfs:label "Consigne Anglais (liste)"@fr , "Task English (list)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList--> ,
 						<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNIL> ,
-						<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNILlocalterms> ,
+						<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNILmodif> ,
 						<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNILfreeint> ,
 						<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-NONUNIL> .
 
@@ -703,11 +696,11 @@
 		knora-base:listNodePosition 1 ;
 		rdfs:label "UNIL"@fr , "UNIL"@en .
 
-<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNILlocalterms> a knora-base:ListNode ;
-		knora-base:listNodeName "UNILlocalterms" ;
+<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNILmodif> a knora-base:ListNode ;
+		knora-base:listNodeName "UNILmodif" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "UNIL strandard, mais avec les termes locaux, p.e. kami, burkhan"@fr , "UNIL standrad but with local terms, e.g. kami, burkhan"@en .
+		rdfs:label "UNIL modifiée"@fr , "UNIL modified"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNILfreeint> a knora-base:ListNode ;
 		knora-base:listNodeName "UNILfreeint" ;
@@ -757,25 +750,25 @@
 		knora-base:listNodeName "japan" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "(JAPANeng) In japanese : When I say \"Kami\" (God), could you please draw anything that comes to your imagination?"@en .
+		rdfs:label "(JAPANeng) In japanese : When I say \"kami\" (god), could you please draw anything that comes to your imagination?"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-nepal> a knora-base:ListNode ;
 		knora-base:listNodeName "nepal" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "(NEPALeng)Free translation into Nepali of \" Have you ever heard of the word \"God\"? Now close your eyes and try to imagine, then draw. Do not look over to your colleagues', because I would like to know how you you imagine or think. Draw as you like and as you imagine."@en .
+		rdfs:label "(NEPALeng)Free translation into Nepali of \" Have you ever heard of the word \"god\"? Now close your eyes and try to imagine, then draw. Do not look over to your colleagues', because I would like to know how you imagine or think. Draw as you like and as you imagine."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-netherlands> a knora-base:ListNode ;
 		knora-base:listNodeName "netherlands" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "(NETHERLANDSeng)Have you ever heard the word \"God\"? Try to make a representation and draw this."@en .
+		rdfs:label "(NETHERLANDSeng)Have you ever heard the word \"god\"? Try to make a representation and draw this."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-romania> a knora-base:ListNode ;
 		knora-base:listNodeName "romania" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "(ROMANIAeng) In Romanian: When I say \"God\", what can you imagine? Can you imagine something? If yes, can you draw it right now?"@en .
+		rdfs:label "(ROMANIAeng) In Romanian: When I say \"god\", what can you imagine? Can you imagine something? If yes, can you draw it right now?"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-russia1> a knora-base:ListNode ;
 		knora-base:listNodeName "russia1" ;
@@ -793,13 +786,13 @@
 		knora-base:listNodeName "switzerland1" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 8 ;
-		rdfs:label "(SWITZ1eng) Have you ever heard of the word \"God\"? Could you draw, please? You can draw anything that comes up to your mind when you think of the word \"God\"."@en .
+		rdfs:label "(SWITZ1eng) Have you ever heard of the word \"god\"? Could you draw, please? You can draw anything that comes up to your mind when you think of the word \"god\"."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-switzerland2> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland2" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 9 ;
-		rdfs:label "(SWITZ2eng)  Have you ever heard of the word \"God\"? Now close your eyes and try to imagine, then draw. Do not look over to your colleagues', because I would like to know how you you imagine or think. Draw as you like and as you imagine."@en .
+		rdfs:label "(SWITZ2eng)  Have you ever heard of the word \"god\"? Now close your eyes and try to imagine, then draw. Do not look over to your colleagues', because I would like to know how you imagine or think. Draw as you like and as you imagine."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-switzerland3> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland3" ;
@@ -811,7 +804,7 @@
 		knora-base:listNodeName "usa" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 11 ;
-		rdfs:label "(USAeng) In English: Please use this piece of paper and the pencils, crayons, and markers to draw a picture of God. There is no right or wrong way to draw the picture, just draw what you think God looks like."@en .
+		rdfs:label "(USAeng) In English: Please use this piece of paper and the pencils, crayons, and markers to draw a picture of god. There is no right or wrong way to draw the picture, just draw what you think god looks like."@en .
 
 
 ###   InstructionFrList
@@ -850,49 +843,49 @@
 		knora-base:listNodeName "japan" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "(JAPANfre) En japonais : Quand je te dis \"Kami\", qu'est-ce que tu peux imaginer/ Peux-tu imaginer quelque chose/ Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \" Dieu \"."@fr .
+		rdfs:label "(JAPANfre) En japonais : Quand je te dis \"kami\", qu'est-ce que tu peux imaginer/ Peux-tu imaginer quelque chose/ Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \" dieu \"."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-nepal> a knora-base:ListNode ;
 		knora-base:listNodeName "nepal" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "(NEPALfre) Traduction libre en Népalais de \"Est-ce que vous avez déjà entendu le mot \"Dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner. Ne regardez pas le dessin de vos voisins car je voudrais savoir comment vous, vous l'imaginez ou pensez. Dessinez comme vous voulez et comme vous l'imaginez."@fr .
+		rdfs:label "(NEPALfre) Traduction libre en Népalais de \"Est-ce que vous avez déjà entendu le mot \"dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner. Ne regardez pas le dessin de vos voisins car je voudrais savoir comment vous, vous l'imaginez ou pensez. Dessinez comme vous voulez et comme vous l'imaginez."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-netherlands> a knora-base:ListNode ;
 		knora-base:listNodeName "netherlands" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "(NETHERLANDSfre) Est-ce que vous avez déjà entendu le mot \"Dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner."@fr .
+		rdfs:label "(NETHERLANDSfre) Est-ce que vous avez déjà entendu le mot \"dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-romania> a knora-base:ListNode ;
 		knora-base:listNodeName "romania" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "(ROMAINIAfre) En roumain : Avez-vous déjà entendu le mot \"Dumnezeu\". Est-ce que vous pouvez me dessiner Dumnezeu sur une feuille, la façon dont vous vous l'imaginez."@fr .
+		rdfs:label "(ROMAINIAfre) En roumain : Avez-vous déjà entendu le mot \"dumnezeu\". Est-ce que vous pouvez me dessiner dumnezeu sur une feuille, la façon dont vous vous l'imaginez."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-russia1> a knora-base:ListNode ;
 		knora-base:listNodeName "russia1" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 6 ;
-		rdfs:label "(RUSSIA1fre) En russe : As-tu déjà entendu le mot \"Bog\". Maintenant, essaye de l'imaginer et dessine-le sur cette feuille."@fr .
+		rdfs:label "(RUSSIA1fre) En russe : As-tu déjà entendu le mot \"bog\". Maintenant, essaye de l'imaginer et dessine-le sur cette feuille."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-russia2> a knora-base:ListNode ;
 		knora-base:listNodeName "russia2" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 7 ;
-		rdfs:label "(RUSSIA2fre) En russe : As-tu déjà entendu le mot \"Bourkhane\" (Dieu en bouriate). Maintenant, essaye de l'imaginer et dessine-le sur cette feuille."@fr .
+		rdfs:label "(RUSSIA2fre) En russe : As-tu déjà entendu le mot \"bourkhane\" (dieu en bouriate). Maintenant, essaye de l'imaginer et dessine-le sur cette feuille."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-switzerland1> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland1" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 8 ;
-		rdfs:label "(SWITZ1fre) Vous avez déjà entendu le mot \"Dieu\" ? Est-ce que vous pouvez me le dessiner s'il vous plaît ? Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \"Dieu\"."@fr .
+		rdfs:label "(SWITZ1fre) Vous avez déjà entendu le mot \"dieu\" ? Est-ce que vous pouvez me le dessiner s'il vous plaît ? Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \"dieu\"."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-switzerland2> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland2" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 9 ;
-		rdfs:label "(SWITZ2fre) Est-ce que vous avez déjà entendu le mot \"Dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner. Ne regardez pas le dessin de vos voisins car je voudrais savoir comment vous, vous l'imaginez ou pensez. Dessinez comme vous voulez et comme vous l'imaginez."@fr .
+		rdfs:label "(SWITZ2fre) Est-ce que vous avez déjà entendu le mot \"dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner. Ne regardez pas le dessin de vos voisins car je voudrais savoir comment vous, vous l'imaginez ou pensez. Dessinez comme vous voulez et comme vous l'imaginez."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-switzerland3> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland3" ;
@@ -904,7 +897,7 @@
 		knora-base:listNodeName "usa" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 11 ;
-		rdfs:label "(USAfre) En anglais: SVP, utilisez ce papier, crayons et marquers pour dessiner un image de Dieu. Il n'a pas de façon correcte ou incorrecte pour dessiner, simplement dessinez comme vous pensez Dieu il est."@fr .
+		rdfs:label "(USAfre) En anglais: SVP, utilisez ce papier, crayons et feutres pour dessiner un image de dieu. Il n'a pas de façon correcte ou incorrecte pour dessiner, simplement dessinez comme vous pensez dieu il est."@fr .
 
 
 ###   LanguageList
@@ -912,7 +905,9 @@
 	knora-base:isRootNode true ;
 	rdfs:comment "Liste de choix pour les langues"@fr ;
 	rdfs:label "Langues (liste)"@fr , "Languages (list)"@en ;
-	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Buriat> ,
+	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-NotAsked> ,
+							<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-None> ,
+							<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Buriat> ,
 							<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-English> ,
 							<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Persian> ,
 							<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-French> ,
@@ -925,76 +920,88 @@
 							<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Romanian> ,
 							<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Russian> .
 
+<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-NotAsked> a knora-base:ListNode ;
+		knora-base:listNodeName "NotAsked" ;
+		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
+		knora-base:listNodePosition 0 ;
+		rdfs:label "Pas demandé"@fr , "Not asked"@en .
+		
+<http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-None> a knora-base:ListNode ;
+		knora-base:listNodeName "None" ;
+		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
+		knora-base:listNodePosition 1 ;
+		rdfs:label "Aucune"@fr , "None"@en .
+		
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Buriat> a knora-base:ListNode ;
 		knora-base:listNodeName "buriat" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 0 ;
+		knora-base:listNodePosition 2 ;
 		rdfs:label "bouriate"@fr , "Buriat"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-English> a knora-base:ListNode ;
 		knora-base:listNodeName "english" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 1 ;
+		knora-base:listNodePosition 3 ;
 		rdfs:label "anglais"@fr , "English"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Persian> a knora-base:ListNode ;
 		knora-base:listNodeName "persian" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 2 ;
+		knora-base:listNodePosition 4 ;
 		rdfs:label "persan"@fr , "Persian"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-French> a knora-base:ListNode ;
 		knora-base:listNodeName "french" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 3 ;
+		knora-base:listNodePosition 5 ;
 		rdfs:label "français"@fr , "French"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Hindi> a knora-base:ListNode ;
 		knora-base:listNodeName "hindi" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 4 ;
+		knora-base:listNodePosition 6 ;
 		rdfs:label "hindi"@fr , "Hindi"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Italian> a knora-base:ListNode ;
 		knora-base:listNodeName "italian" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 5 ;
+		knora-base:listNodePosition 7 ;
 		rdfs:label "italien"@fr , "Italian"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Japanese> a knora-base:ListNode ;
 		knora-base:listNodeName "japanese" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 6 ;
+		knora-base:listNodePosition 8 ;
 		rdfs:label "japonais"@fr , "Japanese"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Nepali> a knora-base:ListNode ;
 		knora-base:listNodeName "nepali" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 7 ;
+		knora-base:listNodePosition 9 ;
 		rdfs:label "népali"@fr , "Nepali"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Dutch> a knora-base:ListNode ;
 		knora-base:listNodeName "dutch" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 8 ;
+		knora-base:listNodePosition 10 ;
 		rdfs:label "néerlandais"@fr , "Dutch"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Portuguese> a knora-base:ListNode ;
 		knora-base:listNodeName "portuguese" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 9 ;
+		knora-base:listNodePosition 11 ;
 		rdfs:label "portugais"@fr , "Portuguese"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Romanian> a knora-base:ListNode ;
 		knora-base:listNodeName "romanian" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 10 ;
+		knora-base:listNodePosition 12 ;
 		rdfs:label "roumain"@fr , "Romanian"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList-Russian> a knora-base:ListNode ;
 		knora-base:listNodeName "russian" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LanguageList> ;
-		knora-base:listNodePosition 11 ;
+		knora-base:listNodePosition 13 ;
 		rdfs:label "russe"@fr , "Russian"@en .
 
 ###    ScannerBrandList
@@ -2342,7 +2349,7 @@
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 				knora-base:listNodeName "panauti" ;
 				knora-base:listNodePosition 2 ;
-				rdfs:label "Town of Panauti"@fr , "ville de Panauti"@en ;
+				rdfs:label "Ville de Panauti"@fr , "Town of Panauti"@en ;
 				knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-kamigaon> .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-kamigaon> a knora-base:ListNode ;
@@ -2768,13 +2775,13 @@
 		knora-base:listNodeName "switzerland1" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionOriginalList> ;
 		knora-base:listNodePosition 8 ;
-		rdfs:label "(SWITZ1or) Vous avez déjà entendu le mot \"Dieu\" ? Est-ce que vous pouvez me le dessiner s'il vous plaît ? Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \"Dieu\"." .
+		rdfs:label "(SWITZ1or) Vous avez déjà entendu le mot \"dieu\" ? Est-ce que vous pouvez me le dessiner s'il vous plaît ? Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \"dieu\"." .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionOriginalList-switzerland2> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland2" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionOriginalList> ;
 		knora-base:listNodePosition 9 ;
-		rdfs:label "(SWITZ2or) Est-ce que vous avez déjà entendu le mot \"Dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner. Ne regardez pas le dessin de vos voisins car je voudrais savoir comment vous, vous l'imaginez ou pensez. Dessinez comme vous voulez et comme vous l'imaginez." .
+		rdfs:label "(SWITZ2or) Est-ce que vous avez déjà entendu le mot \"dieu\" ? Maintenant fermez les yeux et essayez de l'imaginer, puis de dessiner. Ne regardez pas le dessin de vos voisins car je voudrais savoir comment vous, vous l'imaginez ou pensez. Dessinez comme vous voulez et comme vous l'imaginez." .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionOriginalList-switzerland3> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland3" ;
@@ -2786,7 +2793,7 @@
 		knora-base:listNodeName "usa" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionOriginalList> ;
 		knora-base:listNodePosition 11 ;
-		rdfs:label "(USAor) Please use this piece of paper and the pencils, crayons, and markers to draw a picture of God. There is no right or wrong way to draw the picture, just draw what you think God looks like." .
+		rdfs:label "(USAor) Please use this piece of paper and the pencils, crayons, and markers to draw a picture of god. There is no right or wrong way to draw the picture, just draw what you think god looks like." .
 
 
 ###   EthnicityList
@@ -2915,7 +2922,9 @@
 	knora-base:isRootNode true ;
 	rdfs:comment "Liste hiérarchique de choix pour les religions (participants et institutions)"@fr ;
 	rdfs:label "Religion (liste hiérarchique)"@fr , "Religion (hierarchical list)"@en ;
-	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-christian> ,
+	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-notasked> ,
+				<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-notrelinst> ,
+				<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-christian> ,
 				<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-buddhist> ,
 				<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-hinduist> ,
 				<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-jewish> ,
@@ -2926,10 +2935,22 @@
 				<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-zoroastrian> ,
 				<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-other1> .
 
+	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-notasked> a knora-base:ListNode ;
+		knora-base:listNodeName "notasked" ;
+		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
+		knora-base:listNodePosition 0 ;
+		rdfs:label "Pas demandé"@fr , "Not asked"@en .
+		
+	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-notrelinst> a knora-base:ListNode ;
+		knora-base:listNodeName "notrelinst" ;
+		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
+		knora-base:listNodePosition 1 ;
+		rdfs:label "Non-religieuse (pour les institutions)"@fr , "Non-religious (for institutions)"@en .
+									
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-christian> a knora-base:ListNode ;
 		knora-base:listNodeName "christian" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 0 ;
+		knora-base:listNodePosition 2 ;
 		rdfs:label "Chrétien"@fr , "Christian"@en ;
 		knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-catholic> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-protestant> ,
@@ -2963,25 +2984,25 @@
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-buddhist> a knora-base:ListNode ;
 		knora-base:listNodeName "buddhist" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 1 ;
+		knora-base:listNodePosition 3 ;
 		rdfs:label "Bouddhiste"@fr , "Buddhist"@en .
 		
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-hinduist> a knora-base:ListNode ;
 		knora-base:listNodeName "hinduist" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 2 ;
+		knora-base:listNodePosition 4 ;
 		rdfs:label "Hindouiste"@fr , "Hinduist"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-jewish> a knora-base:ListNode ;
 		knora-base:listNodeName "jewish" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 3 ;
+		knora-base:listNodePosition 5 ;
 		rdfs:label "Juif"@fr , "Jewish"@en .
 			
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-muslim> a knora-base:ListNode ;
 		knora-base:listNodeName "muslim" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 4 ;
+		knora-base:listNodePosition 6 ;
 		rdfs:label "Musulmane"@fr , "Muslim"@en ;
 		knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-shiit> ,
 						<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-sunnit> .
@@ -3001,31 +3022,31 @@
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-shamanist> a knora-base:ListNode ;
 		knora-base:listNodeName "shamanist" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 5 ;
-		rdfs:label "Shamaniste"@fr , "Shamanist"@en .
+		knora-base:listNodePosition 7 ;
+		rdfs:label "Chamaniste"@fr , "Shamanist"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-shintoist> a knora-base:ListNode ;
 		knora-base:listNodeName "shintoist" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 6 ;
+		knora-base:listNodePosition 8 ;
 		rdfs:label "Shintoiste"@fr , "Shintoist"@en .			
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-taoist> a knora-base:ListNode ;
 		knora-base:listNodeName "taoist" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 7 ;
+		knora-base:listNodePosition 9 ;
 		rdfs:label "Taoiste"@fr , "Taoist"@en .
 		
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-zoroastrian> a knora-base:ListNode ;
 		knora-base:listNodeName "zoroastrian" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 8 ;
+		knora-base:listNodePosition 10 ;
 		rdfs:label "Zoroastrien"@fr , "Zoroastrian"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-other1> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
-		knora-base:listNodePosition 9 ;
+		knora-base:listNodePosition 11 ;
 		rdfs:label "Autre"@fr , "Other"@en ;
 		knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-atheist> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-doesnotknow> ,
@@ -3973,6 +3994,7 @@
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-weekly> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-monthly> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-yearly> ,
+	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-NewYear> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-fewtimesayear> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-once> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-afterlunch> ,
@@ -4030,6 +4052,12 @@
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ> ;
 		knora-base:listNodePosition 7 ;
 		rdfs:label "Chaque année"@fr , "Early"@en .
+		
+	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-NewYear> a knora-base:ListNode ;
+		knora-base:listNodeName "NewYear" ;
+		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ> ;
+		knora-base:listNodePosition 7 ;
+		rdfs:label "A nouvel an"@fr , "On New Year's eve"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-fewtimesayear> a knora-base:ListNode ;
 		knora-base:listNodeName "fewtimesayear" ;
@@ -4268,8 +4296,8 @@
 	rdfs:comment "Liste de choix pour le visites aux temple au Japon pendant la fête de Nouvelle An"@fr ;
 	rdfs:label "Visite de temple au Japon pendant le Nouvel An (liste)"@fr , "Temple visit in Japan at New Year Eve (list)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-notasked> ,
-	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinjyaotera> ,
-	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinjya> ,
+	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinjaotera> ,
+	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinja> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-otera> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-temple> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-church> ,
@@ -4282,17 +4310,17 @@
 		knora-base:listNodePosition 0 ;
 		rdfs:label "Pas demandé"@fr , "Not asked"@en .
 
-	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinjyaotera> a knora-base:ListNode ;
-		knora-base:listNodeName "jinjyaotera" ;
+	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinjaotera> a knora-base:ListNode ;
+		knora-base:listNodeName "jinjaotera" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 1 ;
-		rdfs:label "jinjya ou otera"@fr , "jinjya or otera"@en .
+		rdfs:label "jinja ou otera"@fr , "jinja or otera"@en .
 
-	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinjya> a knora-base:ListNode ;
-		knora-base:listNodeName "jinjya" ;
+	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinja> a knora-base:ListNode ;
+		knora-base:listNodeName "jinja" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "jinjya"@fr , "jinjya"@en .
+		rdfs:label "jinja"@fr , "jinja"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-otera> a knora-base:ListNode ;
 		knora-base:listNodeName "otera" ;
@@ -4310,7 +4338,7 @@
 		knora-base:listNodeName "church" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "eglise"@fr , "church"@en .
+		rdfs:label "église"@fr , "church"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
@@ -4369,7 +4397,7 @@
 		knora-base:listNodeName "altar" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "altar"@fr , "altar"@en .
+		rdfs:label "autel"@fr , "altar"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
@@ -5000,7 +5028,7 @@
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList> ;
 				knora-base:listNodeName "panauti" ;
 				knora-base:listNodePosition 2 ;
-				rdfs:label "Town of Panauti"@fr , "ville de Panauti"@en .
+				rdfs:label "Ville de Panauti"@fr , "Town of Panauti"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-swayambhunath> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList> ;
@@ -5384,7 +5412,7 @@
 			knora-base:listNodeName "humanoid" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 			knora-base:listNodePosition 1 ;
-			rdfs:label "Figure humanoide"@fr , "humanoid figure"@en ;
+			rdfs:label "Figure humanoïde"@fr , "humanoid figure"@en ;
 			knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-normalhuman> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-culturalfigure> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-religiousfigure> ,
@@ -5463,7 +5491,7 @@
 					knora-base:listNodeName "ganesha" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 4 ;
-					rdfs:label "Ganesh"@fr , "Ganesha"@en .
+					rdfs:label "Ganesa"@fr , "Ganesh"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-jesus> a knora-base:ListNode ;
 					knora-base:listNodeName "jesus" ;
@@ -5553,7 +5581,7 @@
 					knora-base:listNodeName "vishnu" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 19 ;
-					rdfs:label "Vishnu"@fr , "Vishnou"@en .
+					rdfs:label "Vishnu"@fr , "Vishnu"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-greekgod> a knora-base:ListNode ;
 					knora-base:listNodeName "greekgod" ;
@@ -5663,7 +5691,7 @@
 					knora-base:listNodeName "nimb" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 9 ;
-					rdfs:label "Nimbe"@fr , "Nimb"@en .
+					rdfs:label "Nimbe"@fr , "Nimbus"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-noface> a knora-base:ListNode ;
 					knora-base:listNodeName "noface" ;
@@ -5681,7 +5709,7 @@
 					knora-base:listNodeName "onlyeyes" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 12 ;
-					rdfs:label "Ques des yeux (un oeil)"@fr , "Only eyes (or eye)"@en .
+					rdfs:label "Que des yeux (un oeil)"@fr , "Only eyes (or eye)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-manyeyes> a knora-base:ListNode ;
 					knora-base:listNodeName "manyeyes" ;
@@ -5735,13 +5763,13 @@
 					knora-base:listNodeName "symmetrical" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 21 ;
-					rdfs:label "Corps symmétrique"@fr , "Symmetrical body"@en .
+					rdfs:label "Corps symétrique"@fr , "Symmetrical body"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-assymetrical> a knora-base:ListNode ;
 					knora-base:listNodeName "assymetrical" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 22 ;
-					rdfs:label "Corps assymétrique"@fr , "Asymmetrical body"@en .
+					rdfs:label "Corps asymétrique"@fr , "Asymmetrical body"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-unhumanshape> a knora-base:ListNode ;
 					knora-base:listNodeName "unhumanshape" ;
@@ -5782,7 +5810,7 @@
 					knora-base:listNodeName "clothes" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 1 ;
-					rdfs:label "Habits particulers"@fr , "Special clothes"@en ;
+					rdfs:label "Habits particuliers"@fr , "Special clothes"@en ;
 					knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-whiterobe> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-religiousclothes> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-modernclothes> ,
@@ -5993,7 +6021,7 @@
 			knora-base:listNodeName "sunlightrays" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 			knora-base:listNodePosition 4 ;
-			rdfs:label "Soleil, limière"@fr , "Sun, light, rays"@en ;
+			rdfs:label "Soleil, lumière"@fr , "Sun, light, rays"@en ;
 			knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-light> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-rays> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-stars> ,
@@ -6078,13 +6106,13 @@
 				knora-base:listNodeName "colombe" ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 				knora-base:listNodePosition 4 ;
-				rdfs:label "Colombe"@fr , "Colombe"@en .
+				rdfs:label "Colombe"@fr , "Pigeon"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-Coran> a knora-base:ListNode ;
 				knora-base:listNodeName "Coran" ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 				knora-base:listNodePosition 5 ;
-				rdfs:label "Coran"@fr , "Coran"@en .
+				rdfs:label "Coran"@fr , "Koran"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-cross> a knora-base:ListNode ;
 				knora-base:listNodeName "cross" ;
@@ -6132,7 +6160,7 @@
 				knora-base:listNodeName "svastika" ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 				knora-base:listNodePosition 13 ;
-				rdfs:label "Svastika"@fr , "Svastika"@en .
+				rdfs:label "Svastika"@fr , "Swastika"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-tilak> a knora-base:ListNode ;
 				knora-base:listNodeName "tilak" ;
@@ -6162,7 +6190,7 @@
 				knora-base:listNodeName "yinyang" ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 				knora-base:listNodePosition 18 ;
-				rdfs:label "Yinyang"@fr , "Yinyang"@en .
+				rdfs:label "Yin yang"@fr , "Yinyang"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-yantra> a knora-base:ListNode ;
 				knora-base:listNodeName "yantra" ;
@@ -6536,7 +6564,7 @@
 			knora-base:listNodeName "symmetryprominent" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodPositionList> ;
 			knora-base:listNodePosition 10 ;
-			rdfs:label "Image est très symmetrique"@fr , "Drawing is very symmetrical"@en .
+			rdfs:label "Image est très symétrique"@fr , "Drawing is very symmetrical"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-GodPositionList-inpicture> a knora-base:ListNode ;
 			knora-base:listNodeName "inpicture" ;
@@ -6622,8 +6650,7 @@
 	knora-base:isRootNode true ;
 	rdfs:comment "Liste hiérarchique de choix pour l'identité religieuse de l'image"@fr ;
 	rdfs:label "Identité religieuse du dessin"@fr , "Religious identity of the image"@en ;
-	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-clear> ,
-									<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-none> ,
+	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-unclear> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-christian> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-muslim> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-buddhist> ,
@@ -6636,82 +6663,76 @@
 									<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-shamanist> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-other3> .
 
-		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-clear> a knora-base:ListNode ;
-			knora-base:listNodeName "clear" ;
+		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-unclear> a knora-base:ListNode ;
+			knora-base:listNodeName "unclear" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
 			knora-base:listNodePosition 0 ;
-			rdfs:label "L'identité religieuse est claire"@fr , "The image has clear religious identity"@en .
-
-		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-none> a knora-base:ListNode ;
-			knora-base:listNodeName "none" ;
-			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 1 ;
-			rdfs:label "L'image n'a pas d'identité religieuse claire"@fr , "The image has no clear religious identity"@en .
+			rdfs:label "L'identité religieuse non-detéctée"@fr , "The image has no clear religious identity"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-christian> a knora-base:ListNode ;
 			knora-base:listNodeName "christian" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 2 ;
+			knora-base:listNodePosition 1 ;
 			rdfs:label "Chrétien"@fr , "Christian"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-muslim> a knora-base:ListNode ;
 			knora-base:listNodeName "muslim" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 3 ;
+			knora-base:listNodePosition 2 ;
 			rdfs:label "Musulman"@fr , "Muslim"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-buddhist> a knora-base:ListNode ;
 			knora-base:listNodeName "buddhist" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 4 ;
+			knora-base:listNodePosition 3 ;
 			rdfs:label "Bouddhiste"@fr , "Buddhist"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-hindu> a knora-base:ListNode ;
 			knora-base:listNodeName "hindu" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 5 ;
+			knora-base:listNodePosition 4 ;
 			rdfs:label "Hindou"@fr , "Hindu"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-jewish> a knora-base:ListNode ;
 			knora-base:listNodeName "jewish" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 6 ;
+			knora-base:listNodePosition 5 ;
 			rdfs:label "Juif"@fr , "Jewish"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-shinto> a knora-base:ListNode ;
 			knora-base:listNodeName "shinto" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 7 ;
+			knora-base:listNodePosition 6 ;
 			rdfs:label "Shinto"@fr , "Shinto"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-taoist> a knora-base:ListNode ;
 			knora-base:listNodeName "taoist" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 8 ;
-			rdfs:label "Taoist"@fr , "Taoist"@en .
+			knora-base:listNodePosition 7 ;
+			rdfs:label "Taoïste"@fr , "Taoist"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-greek> a knora-base:ListNode ;
 			knora-base:listNodeName "greek" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 9 ;
-			rdfs:label "Greque (ancient)"@fr , "Greek"@en .
+			knora-base:listNodePosition 8 ;
+			rdfs:label "Grecque (ancien)"@fr , "Greek"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-egyptian> a knora-base:ListNode ;
 			knora-base:listNodeName "egyptian" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 10 ;
+			knora-base:listNodePosition 9 ;
 			rdfs:label "Egyptien"@fr , "Egyptian"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-shamanist> a knora-base:ListNode ;
 			knora-base:listNodeName "shamanist" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 11 ;
-			rdfs:label "Shamanist, animalist"@fr , "Shamanist, animalist"@en .
+			knora-base:listNodePosition 10 ;
+			rdfs:label "Chamaniste, animalist"@fr , "Shamanist, animalist"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-other3> a knora-base:ListNode ;
 			knora-base:listNodeName "other" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
-			knora-base:listNodePosition 12 ;
+			knora-base:listNodePosition 11 ;
 			rdfs:label "Autre tradition religieuse"@fr , "Other religious tradition"@en .
 
 

--- a/drawings-gods_data-lists.ttl
+++ b/drawings-gods_data-lists.ttl
@@ -15,8 +15,8 @@
 ###   AdditionalTaskList
 <http://rdfh.ch/lists/drawings-gods-2016-list-AdditionalTaskList> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour les devoirs additionnels"@fr ;
-	rdfs:label "Devoirs additionnels (liste)"@fr , "Additional tasks (list)"@en ;
+	rdfs:comment "Liste de choix pour les tâches additionnelles"@fr ;
+	rdfs:label "Tâches additionnelles (liste)"@fr , "Additional tasks (list)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-AdditionalTaskList--> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-AdditionalTaskList-attachmentTest> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-AdditionalTaskList-drawingParent> ,
@@ -160,7 +160,7 @@
 <http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
 	rdfs:comment "Liste hiérarchique de choix pour la localisation du site niveau pays et région"@fr ;
-	rdfs:label "Localisation niveau pays et région (liste hiérarchique)"@fr , "Location du site level country and region (hierarchical list)"@en ;
+	rdfs:label "Localisation niveau pays et région (liste hiérarchique)"@fr , "Location, level country and region (hierarchical list)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList-switzerland> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList-iran> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList-japan> ,
@@ -205,7 +205,7 @@
 			knora-base:listNodeName "juraCanton" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList> ;
 			knora-base:listNodePosition 3 ;
-			rdfs:label "Canton de Jura"@fr , "Jura Canton"@en .
+			rdfs:label "Canton du Jura"@fr , "Jura Canton"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList-neuchatelCanton> a knora-base:ListNode ;
 			knora-base:listNodeName "neuchatelCanton" ;
@@ -217,7 +217,7 @@
 			knora-base:listNodeName "valaisCanton" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList> ;
 			knora-base:listNodePosition 5 ;
-			rdfs:label "Canton de Valais"@fr , "Valais Canton"@en .
+			rdfs:label "Canton du Valais"@fr , "Valais Canton"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-GlobalLocationHList-vaudCanton> a knora-base:ListNode ;
 			knora-base:listNodeName "vaudCanton" ;
@@ -624,7 +624,7 @@
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList> ;
 				knora-base:listNodeName "layschool" ;
 				knora-base:listNodePosition 0 ;
-				rdfs:label "Ecole laïque"@fr , "Public school"@en .
+				rdfs:label "Ecole publique"@fr , "Public school"@en .
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList-relschool> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-CollSiteList> ;
@@ -675,8 +675,8 @@
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour la consigne en Anglais"@fr ;
-	rdfs:label "Consigne Anglais (liste)"@fr , "Task English (list)"@en ;
+	rdfs:comment "Liste de choix pour le type de consigne"@fr ;
+	rdfs:label "Type de consigne (liste)"@fr , "Task type (list)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList--> ,
 						<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNIL> ,
 						<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionCodeList-UNILmodif> ,
@@ -756,13 +756,13 @@
 		knora-base:listNodeName "nepal" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "(NEPALeng)Free translation into Nepali of \" Have you ever heard of the word \"god\"? Now close your eyes and try to imagine, then draw. Do not look over to your colleagues', because I would like to know how you imagine or think. Draw as you like and as you imagine."@en .
+		rdfs:label "(NEPALeng) Free translation into Nepali of \" Have you ever heard of the word \"god\"? Now close your eyes and try to imagine, then draw. Do not look over to your colleagues', because I would like to know how you imagine or think. Draw as you like and as you imagine."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-netherlands> a knora-base:ListNode ;
 		knora-base:listNodeName "netherlands" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "(NETHERLANDSeng)Have you ever heard the word \"god\"? Try to make a representation and draw this."@en .
+		rdfs:label "(NETHERLANDSeng) Have you ever heard the word \"god\"? Try to make a representation and draw this."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-romania> a knora-base:ListNode ;
 		knora-base:listNodeName "romania" ;
@@ -774,13 +774,13 @@
 		knora-base:listNodeName "russia1" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 6 ;
-		rdfs:label "(RUSSIA1eng)In Russian : Have you ever heard the word \"god\"? Now close your eyes and try to imagine. Have you imagined? Now draw what you have imagined."@en .
+		rdfs:label "(RUSSIA1eng) In Russian : Have you ever heard the word \"god\"? Now close your eyes and try to imagine. Have you imagined? Now draw what you have imagined."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-russia2> a knora-base:ListNode ;
 		knora-base:listNodeName "russia2" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList> ;
 		knora-base:listNodePosition 7 ;
-		rdfs:label "(RUSSIA2eng)In Russian : Have you ever heard of the word \"burkhan\"? Now close your eyes and try to imagine. Have you imagined? Now draw what you have imagined."@en .
+		rdfs:label "(RUSSIA2eng) In Russian : Have you ever heard of the word \"burkhan\"? Now close your eyes and try to imagine. Have you imagined? Now draw what you have imagined."@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionEnList-switzerland1> a knora-base:ListNode ;
 		knora-base:listNodeName "switzerland1" ;
@@ -843,7 +843,7 @@
 		knora-base:listNodeName "japan" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "(JAPANfre) En japonais : Quand je te dis \"kami\", qu'est-ce que tu peux imaginer/ Peux-tu imaginer quelque chose/ Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \" dieu \"."@fr .
+		rdfs:label "(JAPANfre) En japonais : Quand je te dis \"kami\", qu'est-ce que tu peux imaginer/ peux-tu imaginer quelque chose? Vous pouvez dessiner tout ce qui vous vient à l'esprit lorsque vous pensez au mot \" dieu \"."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-nepal> a knora-base:ListNode ;
 		knora-base:listNodeName "nepal" ;
@@ -861,7 +861,7 @@
 		knora-base:listNodeName "romania" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "(ROMAINIAfre) En roumain : Avez-vous déjà entendu le mot \"dumnezeu\". Est-ce que vous pouvez me dessiner dumnezeu sur une feuille, la façon dont vous vous l'imaginez."@fr .
+		rdfs:label "(ROMAINIAfre) En roumain : Avez-vous déjà entendu le mot \"dumnezeu\". Est-ce que vous pouvez me dessiner \"dumnezeu\" sur une feuille, la façon dont vous vous l'imaginez."@fr .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList-russia1> a knora-base:ListNode ;
 		knora-base:listNodeName "russia1" ;
@@ -897,7 +897,7 @@
 		knora-base:listNodeName "usa" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionFrList> ;
 		knora-base:listNodePosition 11 ;
-		rdfs:label "(USAfre) En anglais: SVP, utilisez ce papier, crayons et feutres pour dessiner un image de dieu. Il n'a pas de façon correcte ou incorrecte pour dessiner, simplement dessinez comme vous pensez dieu il est."@fr .
+		rdfs:label "(USAfre) En anglais: S'il vous plaît, utilisez ce papier, ces crayons et ces feutres pour dessiner une image de dieu. Il n'y a pas de façon correcte ou incorrecte de dessiner, simplement dessinez comme vous pensez que dieu est."@fr .
 
 
 ###   LanguageList
@@ -1049,7 +1049,7 @@
 <http://rdfh.ch/lists/drawings-gods-2016-list-ScannerSettingsList> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
 	rdfs:comment "Liste de contrôle de la conformité des numérisation"@fr ;
-	rdfs:label "Images conformes"@fr , "Images fit to standard"@en ;
+	rdfs:label "Images conformes (numérisation)"@fr , "Images fit to standard (digitisation)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-ScannerSettingsList-yes> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-ScannerSettingsList-no> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-ScannerSettingsList-idontknow> ,
@@ -1156,7 +1156,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "petitprince" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Ecole primaire d'Attalens Le Petit Prince (ras)"@fr , "Ecole primaire d'Attalens Le Petit Prince (ras)"@en .
+					rdfs:label "Ecole primaire d'Attalens Le Petit Prince (ras)"@fr , "Primary school of Attalens Le Petit Prince (ras)"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-bossonnens> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -1169,7 +1169,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "epbossonnens" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Ecole publique Ecole primaire de Bossonnens (rbe)"@fr , "Public school Ecole primaire de Bossonnens (rbe)"@en .
+					rdfs:label "Ecole publique Ecole primaire de Bossonnens (rbe)"@fr , "Public school Primary school of Bossonnens (rbe)"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-bulle> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -1222,7 +1222,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "epestavayer" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Ecole publique CEP d'Estavayer-le-lac (rec)"@fr , "Public school CEP d'Estavayer-le-lac (rec)"@en .
+					rdfs:label "Ecole publique CEP d'Estavayer-le-lac (rec)"@fr , "Public school CEP of Estavayer-le-lac (rec)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-coestavayer> a knora-base:ListNode ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -1330,7 +1330,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "chatelaine" ;
 					knora-base:listNodePosition 2 ;
-					rdfs:label "Paroisse Eglise Saint-Pie X à Châtelaine (rpi)"@fr , "Parish Eglise Saint-Pie X in Chatelaine (rpi)"@en .
+					rdfs:label "Paroisse Eglise Saint-Pie X à Châtelaine (rpi)"@fr , "Parish Church Saint-Pie X in Chatelaine (rpi)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-contamines> a knora-base:ListNode ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -1367,7 +1367,7 @@
 			knora-base:listNodeName "juraCanton" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 			knora-base:listNodePosition 3 ;
-			rdfs:label "Canton de Jura"@fr , "Jura Canton"@en ;
+			rdfs:label "Canton du Jura"@fr , "Jura Canton"@en ;
 			knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-vicques> .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-vicques> a knora-base:ListNode ;
@@ -1435,7 +1435,7 @@
 			knora-base:listNodeName "valaisCanton" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 			knora-base:listNodePosition 5 ;
-			rdfs:label "Canton de Valais"@fr , "Valais Canton"@en ;
+			rdfs:label "Canton du Valais"@fr , "Valais Canton"@en ;
 			knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-bassenendaz> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-hautenendaz> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-saintgingolph> .
@@ -1639,7 +1639,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "erprolle" ;
 					knora-base:listNodePosition 1 ;
-					rdfs:label "Ecole religieuse Paroisse de Rolle (rro)"@fr , "Religious school Paroisse de Rolle (rro)"@en .
+					rdfs:label "Ecole religieuse Paroisse de Rolle (rro)"@fr , "Religious school Parish of Rolle (rro)"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-saintprex> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -1652,7 +1652,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "erstprex" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Ecole religieuse Salle de paroisse de Saint-Prex (rsp)"@fr , "Religious school Salle de paroisse de Saint-Prex (rsp)"@en .
+					rdfs:label "Ecole religieuse Salle de paroisse de Saint-Prex (rsp)"@fr , "Religious school Room of the parish of Saint-Prex (rsp)"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-tolochenaz> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -1665,7 +1665,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "poste" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Salle de l'Ancienne Poste (rtz)"@fr , "Salle de l'Ancienne Poste (rtz)"@en .
+					rdfs:label "Salle de l'Ancienne Poste (rtz)"@fr , "Room of the Ancienne Poste (rtz)"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-iran> a knora-base:ListNode ;
 		knora-base:listNodeName "iran" ;
@@ -1762,7 +1762,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "bahadari" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Ecole publique Shahid Bahadori (pba)"@fr , "Shahid Bahadori (pba)"@en .
+					rdfs:label "Ecole publique Shahid Bahadori (pba)"@fr , "Public school Shahid Bahadori (pba)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-bani> a knora-base:ListNode ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -2330,7 +2330,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "tekhu" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "A coté de temple de Tekhu (rtk)"@fr , "near the Tekhu temple (rtk)"@en .
+					rdfs:label "A coté de temple de Tekhu (rtk)"@fr , "Near the Tekhu temple (rtk)"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-khopasi> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -2356,7 +2356,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "kamigaon" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Village de forgerons de Kamigaon (pkm)"@fr , "Village of blacksmiths de Kamigaon (pkm)"@en .
+					rdfs:label "Village de forgerons de Kamigaon (pkm)"@fr , "Village of blacksmiths of Kamigaon (pkm)"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-swayambhunath> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -2369,7 +2369,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "swayam" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "A coté de temple de Swayambhounath (rsw)"@fr , "Near Swayambhunath temple (rsw)"@en .
+					rdfs:label "A coté du temple de Swayambhounath (rsw)"@fr , "Near the Swayambhunath temple (rsw)"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-netherlands> a knora-base:ListNode ;
 		knora-base:listNodeName "netherlands" ;
@@ -2487,7 +2487,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "epbrasov" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Ecole publique en ville de Brasov (pb)"@fr , "Public school in the city of Brasov (pb)"@en .
+					rdfs:label "Ecole publique dans la ville de Brasov (pb)"@fr , "Public school in the city of Brasov (pb)"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-moldaviaCounty> a knora-base:ListNode ;
 			knora-base:listNodeName "moldaviaCounty" ;
@@ -2509,13 +2509,13 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "bancila" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Octav Băncilă National College of Art (pi)"@fr , "Octav Băncilă National College of Art (pi)"@en .
+					rdfs:label "Octav Băncilă National Collège National d'Art (pi)"@fr , "Octav Băncilă National College of Art (pi)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-mihail> a knora-base:ListNode ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "mihail" ;
 					knora-base:listNodePosition 1 ;
-					rdfs:label "Mihail Kogalniceanu Elementary School, école subordonnée à Costache Antoniu Elementary and Middle School, Tiganasi (pi)"@fr , "Mihail Kogalniceanu Elementary School, school subordinated to Costache Antoniu Elementary and Middle School, Tiganasi (pi)"@en .
+					rdfs:label "Ecole élémentaire Mihail Kogalniceanu , école subordonnée à Costache Antoniu, école élémentaire et secondaire inférieure, Tiganasi (pi)"@fr , "Mihail Kogalniceanu Elementary School, school subordinated to Costache Antoniu Elementary and Middle School, Tiganasi (pi)"@en .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-moldavia> a knora-base:ListNode ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -2530,19 +2530,19 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "bujor" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Paul Bujor High School, Beresti (urbain) (pv)"@fr , "Paul Bujor High School, Beresti (urban) (pv)"@en .
+					rdfs:label "Ecole secondaire supérieure Paul Bujor, Beresti (urbain) (pv)"@fr , "Paul Bujor High School, Beresti (urban) (pv)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-grigor> a knora-base:ListNode ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "grigor" ;
 					knora-base:listNodePosition 1 ;
-					rdfs:label "No.2 Grigore Hagiu, Middle School, Tg. Bujor (urbain) (pv)"@fr , "No.2 Grigore Hagiu, Middle School, Tg. Bujor (urban) (pv)"@en .
+					rdfs:label "No.2 Grigore Hagiu, école secondaire inférieure, Tg. Bujor (urbain) (pv)"@fr , "No.2 Grigore Hagiu, Middle School, Tg. Bujor (urban) (pv)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-traian> a knora-base:ListNode ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "traian" ;
 					knora-base:listNodePosition 2 ;
-					rdfs:label "Traian Elementary School (subordonnée à Braniste Middle School) (rurale) (pr)"@fr , "Traian Elementary School (subordinated to Braniste Middle School) (rural) (pr)"@en .
+					rdfs:label "Ecole élémentaire Traian (subordonnée à Braniste, école secondaire supérieure) (rurale) (pr)"@fr , "Traian Elementary School (subordinated to Braniste Middle School) (rural) (pr)"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-russia> a knora-base:ListNode ;
 		knora-base:listNodeName "russia" ;
@@ -2571,7 +2571,7 @@
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
 					knora-base:listNodeName "ortho" ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Paroisses orthodoxes, écoles de dimanche (6 lieux) (ro, rb, etc)"@fr , "Orthodox parishes, Sunday schools (6 places) (ro, rb, etc)"@en .
+					rdfs:label "Paroisses orthodoxes, écoles du dimanche (6 lieux) (ro, rb, etc)"@fr , "Orthodox parishes, Sunday schools (6 places) (ro, rb, etc)"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList-gym> a knora-base:ListNode ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-SchoolHList> ;
@@ -2751,7 +2751,7 @@
 		knora-base:listNodeName "netherlands" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-InstructionOriginalList> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "(NETHERLANDSor)" .
+		rdfs:label "(NETHERLANDSor) Heb je ooit het woord \"god\" gehoord? Probeer je er een voorstelling van te maken en teken dit." .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-InstructionOriginalList-romania> a knora-base:ListNode ;
 		knora-base:listNodeName "romania" ;
@@ -2878,7 +2878,7 @@
 		knora-base:listNodeName "greek" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-NationalityList> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "Grecque"@fr , "Greek"@en .
+		rdfs:label "Grec"@fr , "Greek"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-NationalityList-iranian> a knora-base:ListNode ;
 		knora-base:listNodeName "iranian" ;
@@ -3003,7 +3003,7 @@
 		knora-base:listNodeName "muslim" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
 		knora-base:listNodePosition 6 ;
-		rdfs:label "Musulmane"@fr , "Muslim"@en ;
+		rdfs:label "Musulman"@fr , "Muslim"@en ;
 		knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-shiit> ,
 						<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-sunnit> .
 			
@@ -3011,7 +3011,7 @@
 			knora-base:listNodeName "shiit" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
 			knora-base:listNodePosition 0 ;
-			rdfs:label "shiite"@fr , "Shia"@en .
+			rdfs:label "Shiite"@fr , "Shia"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-sunnit> a knora-base:ListNode ;
 			knora-base:listNodeName "sunnit" ;
@@ -3029,13 +3029,13 @@
 		knora-base:listNodeName "shintoist" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
 		knora-base:listNodePosition 8 ;
-		rdfs:label "Shintoiste"@fr , "Shintoist"@en .			
+		rdfs:label "Shintoïste"@fr , "Shintoist"@en .			
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-taoist> a knora-base:ListNode ;
 		knora-base:listNodeName "taoist" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList> ;
 		knora-base:listNodePosition 9 ;
-		rdfs:label "Taoiste"@fr , "Taoist"@en .
+		rdfs:label "Taoïste"@fr , "Taoist"@en .
 		
 	<http://rdfh.ch/lists/drawings-gods-2016-list-ReligiousIdentityHList-zoroastrian> a knora-base:ListNode ;
 		knora-base:listNodeName "zoroastrian" ;
@@ -3102,7 +3102,7 @@
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-StorageList> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour les classeurs physiques dans lesquels les images sont placés"@fr ;
+	rdfs:comment "Liste de choix pour les classeurs physiques dans lesquels les images sont placées"@fr ;
 	rdfs:label "Stockage (liste)"@fr , "Storage (list)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-StorageList-CH> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-StorageList-RO> ,
@@ -3775,7 +3775,7 @@
 		knora-base:listNodeName "rathernot" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-AgreementRelatedListQ> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "Plutôt non"@fr , "Rather not"@en .
+		rdfs:label "Plutôt non"@fr , "Rather no"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-AgreementRelatedListQ-notparticularly> a knora-base:ListNode ;
 		knora-base:listNodeName "notparticularly" ;
@@ -4021,13 +4021,13 @@
 		knora-base:listNodeName "beforemeals" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "Avant manger"@fr , "Before meals"@en .
+		rdfs:label "Avant les repas"@fr , "Before meals"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-evenings> a knora-base:ListNode ;
 		knora-base:listNodeName "evenings" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "Les soirs"@fr , "in the evenings"@en .
+		rdfs:label "Les soirs"@fr , "In the evenings"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-daily> a knora-base:ListNode ;
 		knora-base:listNodeName "daily" ;
@@ -4081,13 +4081,13 @@
 		knora-base:listNodeName "threetimesday" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ> ;
 		knora-base:listNodePosition 11 ;
-		rdfs:label "Trois fois par jour fois"@fr , "Three times a day"@en .
+		rdfs:label "Trois fois par jour"@fr , "Three times a day"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-fivetimesday> a knora-base:ListNode ;
 		knora-base:listNodeName "fivetimesday" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ> ;
 		knora-base:listNodePosition 12 ;
-		rdfs:label "Cinq fois par jour fois"@fr , "Five times a day"@en .
+		rdfs:label "Cinq fois par jour"@fr , "Five times a day"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-TimeRelatedListQ-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
@@ -4118,7 +4118,7 @@
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour références possible de l'âge des dieux"@fr ;
+	rdfs:comment "Liste de choix pour référence possible de l'âge de(s) dieu(x)"@fr ;
 	rdfs:label "Age de dieu (liste)"@fr , "Age of god (list)"@en ;
 	knora-base:hasSubListNode 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ-notasked> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ-veryyoung> ,
@@ -4137,25 +4137,25 @@
 		knora-base:listNodeName "veryyoung" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ> ;
 		knora-base:listNodePosition 1 ;
-		rdfs:label "très jeune"@fr , "very young"@en .
+		rdfs:label "Très jeune"@fr , "Very young"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ-young> a knora-base:ListNode ;
 		knora-base:listNodeName "young" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "jeune"@fr , "young"@en .
+		rdfs:label "Jeune"@fr , "Young"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ-old> a knora-base:ListNode ;
 		knora-base:listNodeName "old" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "vieux"@fr , "old"@en .
+		rdfs:label "Vieux"@fr , "Old"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "autre"@fr , "other"@en .
+		rdfs:label "Autre"@fr , "Other"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodAgeListQ-noanswer> a knora-base:ListNode ;
 		knora-base:listNodeName "noanswer" ;
@@ -4169,7 +4169,7 @@
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-GodRelListQ> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour références possible aux dieux"@fr ;
+	rdfs:comment "Liste de choix pour référence possible à/aux dieu(x)"@fr ;
 	rdfs:label "Nom de dieu (liste)"@fr , "Name of god (list)"@en ;
 	knora-base:hasSubListNode 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodRelListQ-notasked> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodRelListQ-jesus> ,
@@ -4202,7 +4202,7 @@
 		knora-base:listNodeName "muhammad" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodRelListQ> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "Muhammad"@fr , "Muhammad"@en .
+		rdfs:label "Mohammad"@fr , "Muhammad"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodRelListQ-allah> a knora-base:ListNode ;
 		knora-base:listNodeName "allah" ;
@@ -4235,7 +4235,7 @@
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour références possible de sex des dieux"@fr ;
+	rdfs:comment "Liste de choix pour référence possible au sexe de(s) dieu(x)"@fr ;
 	rdfs:label "Genre de dieu (liste)"@fr , "Sex of god (list)"@en ;
 	knora-base:hasSubListNode 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ-notasked> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ-female> ,
@@ -4255,31 +4255,31 @@
 		knora-base:listNodeName "female" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ> ;
 		knora-base:listNodePosition 1 ;
-		rdfs:label "féminin"@fr , "Female"@en .
+		rdfs:label "Féminin"@fr , "Female"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ-male> a knora-base:ListNode ;
 		knora-base:listNodeName "male" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "masculin"@fr , "male"@en .
+		rdfs:label "Masculin"@fr , "male"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ-neuter> a knora-base:ListNode ;
 		knora-base:listNodeName "neuter" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "neutre"@fr , "neuter"@en .
+		rdfs:label "Neutre"@fr , "Neuter"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ-malefemale> a knora-base:ListNode ;
 		knora-base:listNodeName "malefemale" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "masculin et féminin"@fr , "male and female"@en .
+		rdfs:label "Masculin et féminin"@fr , "Male and female"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "autre"@fr , "other"@en .
+		rdfs:label "Autre"@fr , "Other"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-GodSexListQ-noanswer> a knora-base:ListNode ;
 		knora-base:listNodeName "noanswer" ;
@@ -4293,8 +4293,8 @@
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour le visites aux temple au Japon pendant la fête de Nouvelle An"@fr ;
-	rdfs:label "Visite de temple au Japon pendant le Nouvel An (liste)"@fr , "Temple visit in Japan at New Year Eve (list)"@en ;
+	rdfs:comment "Liste de choix pour les visites au temple au Japon pendant la fête de Nouvelle An"@fr ;
+	rdfs:label "Visite du temple au Japon pendant le Nouvel An (liste)"@fr , "Temple visit in Japan at New Year Eve (list)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-notasked> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinjaotera> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinja> ,
@@ -4314,37 +4314,37 @@
 		knora-base:listNodeName "jinjaotera" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 1 ;
-		rdfs:label "jinja ou otera"@fr , "jinja or otera"@en .
+		rdfs:label "Jinja ou otera"@fr , "Jinja or otera"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-jinja> a knora-base:ListNode ;
 		knora-base:listNodeName "jinja" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "jinja"@fr , "jinja"@en .
+		rdfs:label "Jinja"@fr , "Jinja"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-otera> a knora-base:ListNode ;
 		knora-base:listNodeName "otera" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "otera"@fr , "otera"@en .
+		rdfs:label "Otera"@fr , "Otera"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-temple> a knora-base:ListNode ;
 		knora-base:listNodeName "temple" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "temple"@fr , "temple"@en .
+		rdfs:label "Temple"@fr , "Temple"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-church> a knora-base:ListNode ;
 		knora-base:listNodeName "church" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "église"@fr , "church"@en .
+		rdfs:label "Eglise"@fr , "Church"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ> ;
 		knora-base:listNodePosition 6 ;
-		rdfs:label "autre"@fr , "other"@en .
+		rdfs:label "Autre"@fr , "Other"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanNYListQ-noanswer> a knora-base:ListNode ;
 		knora-base:listNodeName "noanswer" ;
@@ -4379,31 +4379,31 @@
 		knora-base:listNodeName "butsudankamidana" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ> ;
 		knora-base:listNodePosition 1 ;
-		rdfs:label "butsudan ou kamidana"@fr , "butsudan or kamidana"@en .
+		rdfs:label "Butsudan ou kamidana"@fr , "Butsudan or kamidana"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ-butsudan> a knora-base:ListNode ;
 		knora-base:listNodeName "butsudan" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "butsudan"@fr , "butsudan"@en .
+		rdfs:label "Butsudan"@fr , "Butsudan"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ-kamidana> a knora-base:ListNode ;
 		knora-base:listNodeName "kamidana" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "kamidana"@fr , "kamidana"@en .
+		rdfs:label "Kamidana"@fr , "Kamidana"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ-altar> a knora-base:ListNode ;
 		knora-base:listNodeName "altar" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "autel"@fr , "altar"@en .
+		rdfs:label "Autel"@fr , "Altar"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ-other> a knora-base:ListNode ;
 		knora-base:listNodeName "other" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ> ;
 		knora-base:listNodePosition 5 ;
-		rdfs:label "autre"@fr , "other"@en .
+		rdfs:label "Autre"@fr , "Other"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-JapanObjectListQ-noanswer> a knora-base:ListNode ;
 		knora-base:listNodeName "noanswer" ;
@@ -4418,8 +4418,8 @@
 
 <http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste de choix pour références possible aux places des dieux"@fr ;
-	rdfs:label "Place de dieu (liste)"@fr , "Place of god (list)"@en ;
+	rdfs:comment "Liste de choix pour référence possible à la position de(s) dieu(x)"@fr ;
+	rdfs:label "Position de dieu (liste)"@fr , "Location of god (list)"@en ;
 	knora-base:hasSubListNode 	<http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ-notasked> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ-sky> ,
 	<http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ-earth> ,
@@ -4444,25 +4444,25 @@
 		knora-base:listNodeName "sky" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ> ;
 		knora-base:listNodePosition 1 ;
-		rdfs:label "ciel"@fr , "sky"@en .
+		rdfs:label "Ciel"@fr , "Sky"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ-earth> a knora-base:ListNode ;
 		knora-base:listNodeName "earth" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ> ;
 		knora-base:listNodePosition 2 ;
-		rdfs:label "terre"@fr , "earth"@en .
+		rdfs:label "Terre"@fr , "Earth"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ-sun> a knora-base:ListNode ;
 		knora-base:listNodeName "sun" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ> ;
 		knora-base:listNodePosition 3 ;
-		rdfs:label "soleil"@fr , "sun"@en .
+		rdfs:label "Soleil"@fr , "Sun"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ-everywhere> a knora-base:ListNode ;
 		knora-base:listNodeName "everywhere" ;
 		knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ> ;
 		knora-base:listNodePosition 4 ;
-		rdfs:label "partout"@fr , "everywhere"@en .
+		rdfs:label "Partout"@fr , "Everywhere"@en .
 
 	<http://rdfh.ch/lists/drawings-gods-2016-list-LocGodListQ-self> a knora-base:ListNode ;
 		knora-base:listNodeName "self" ;
@@ -4511,8 +4511,8 @@
 ###    VillageHList
 <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList> a knora-base:ListNode ;
 	knora-base:isRootNode true ;
-	rdfs:comment "Liste hiérarchique de choix pour la localisation du site niveau village"@fr ;
-	rdfs:label "Localisation till village level (liste hiérarchique)"@fr , "Location du site niveau village (hierarchical list)"@en ;
+	rdfs:comment "Liste hiérarchique de choix pour la localisation du site au niveau village"@fr ;
+	rdfs:label "Location du site niveau village (hierarchical list)"@fr , "Localisation till village level (liste hiérarchique)"@en ;
 	knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-switzerland> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-iran> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-japan> ,
@@ -4662,7 +4662,7 @@
 			knora-base:listNodeName "juraCanton" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList> ;
 			knora-base:listNodePosition 3 ;
-			rdfs:label "Canton de Jura"@fr , "Jura Canton"@en ;
+			rdfs:label "Canton du Jura"@fr , "Jura Canton"@en ;
 			knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-vicques> .
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-vicques> a knora-base:ListNode ;
@@ -4695,7 +4695,7 @@
 			knora-base:listNodeName "valaisCanton" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList> ;
 			knora-base:listNodePosition 5 ;
-			rdfs:label "Canton de Valais"@fr , "Valais Canton"@en ;
+			rdfs:label "Canton du Valais"@fr , "Valais Canton"@en ;
 			knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-bassenendaz> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-hautenendaz> ,
 									<http://rdfh.ch/lists/drawings-gods-2016-list-VillageHList-saintgingolph> .
@@ -5491,7 +5491,7 @@
 					knora-base:listNodeName "ganesha" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 4 ;
-					rdfs:label "Ganesa"@fr , "Ganesh"@en .
+					rdfs:label "Ganesh"@fr , "Ganesha"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-jesus> a knora-base:ListNode ;
 					knora-base:listNodeName "jesus" ;
@@ -5545,7 +5545,7 @@
 					knora-base:listNodeName "mohammed" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 13 ;
-					rdfs:label "Mohammed"@fr , "Mohammed"@en .
+					rdfs:label "Mohammed"@fr , "Muhammed"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-shiva> a knora-base:ListNode ;
 					knora-base:listNodeName "shiva" ;
@@ -5793,7 +5793,7 @@
 				knora-base:listNodeName "specialapara" ;
 				knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 				knora-base:listNodePosition 4 ;
-				rdfs:label "Figure humaine, mais avec des particularités pour les habits ou des decorations"@fr , "Usual human figure, but having particularities in clothing or decor"@en ;
+				rdfs:label "Figure humaine, mais avec des particularités pour les habits ou des décorations"@fr , "Usual human figure, but having particularities in clothing or decor"@en ;
 				knora-base:hasSubListNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-ayudhas> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-clothes> ,
 										<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-decorations> ,
@@ -5804,7 +5804,7 @@
 					knora-base:listNodeName "ayudhas" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "La figures tient des armes"@fr , "The figure holds arms"@en .
+					rdfs:label "La figure tient des armes"@fr , "The figure holds arms"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-clothes> a knora-base:ListNode ;
 					knora-base:listNodeName "clothes" ;
@@ -5876,7 +5876,7 @@
 					knora-base:listNodeName "arms" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 0 ;
-					rdfs:label "Position des mains spéciale"@fr , "Special position of the arms and hands"@en .
+					rdfs:label "Position spéciale des mains et des bras"@fr , "Special position of the arms and hands"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-asana> a knora-base:ListNode ;
 					knora-base:listNodeName "asana" ;
@@ -5888,7 +5888,7 @@
 					knora-base:listNodeName "sittingonthrone" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 2 ;
-					rdfs:label "Sur un trône"@fr , "Sitting on the throne"@en .
+					rdfs:label "Assis sur un trône"@fr , "Sitting on the throne"@en .
 
 				<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-face> a knora-base:ListNode ;
 					knora-base:listNodeName "face" ;
@@ -5912,7 +5912,7 @@
 					knora-base:listNodeName "3quarts" ;
 					knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList> ;
 					knora-base:listNodePosition 6 ;
-					rdfs:label "Trois quarts de visage vers le spectateur"@fr , "Three quarters of the face is towards the viewer"@en .
+					rdfs:label "Trois quarts du visage vers le spectateur"@fr , "Three quarters of the face is towards the viewer"@en .
 
 
 			<http://rdfh.ch/lists/drawings-gods-2016-list-FiguresHList-gender> a knora-base:ListNode ;
@@ -6467,7 +6467,7 @@
 			knora-base:listNodeName "otherfunction" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodFunctionList> ;
 			knora-base:listNodePosition 22 ;
-			rdfs:label "Dieu a une autre fonction (à préciser dans le comm.)"@fr , "God has another function (Note in the commentary)"@en .
+			rdfs:label "Dieu a une autre fonction (à préciser dans le comm.)"@fr , "God has another function (Note in the comment)"@en .
 
 
 ###    GodPositionList
@@ -6606,7 +6606,7 @@
 			knora-base:listNodeName "citycontext" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodPositionList> ;
 			knora-base:listNodePosition 17 ;
-			rdfs:label "Dieu est dans le contexte d'une ville/village"@fr , "God is in the context of town or village"@en .
+			rdfs:label "Dieu est dans le contexte d'une ville ou d'un village"@fr , "God is in the context of town or village"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-GodPositionList-amonghumans> a knora-base:ListNode ;
 			knora-base:listNodeName "amonghumans" ;
@@ -6642,7 +6642,7 @@
 			knora-base:listNodeName "otherpos" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-GodPositionList> ;
 			knora-base:listNodePosition 23 ;
-			rdfs:label "Dieu a une autre position (à préciser dans le comm.)"@fr , "God has another position (note in the commentary)"@en .
+			rdfs:label "Dieu a une autre position (à préciser dans le comm.)"@fr , "God has another position (note in the comment)"@en .
 
 
 ###    DrawingReligiousIdentityList
@@ -6667,7 +6667,7 @@
 			knora-base:listNodeName "unclear" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
 			knora-base:listNodePosition 0 ;
-			rdfs:label "L'identité religieuse non-detéctée"@fr , "The image has no clear religious identity"@en .
+			rdfs:label "L'identité religieuse n'est pas claire"@fr , "The image has no clear religious identity"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-christian> a knora-base:ListNode ;
 			knora-base:listNodeName "christian" ;
@@ -6703,7 +6703,7 @@
 			knora-base:listNodeName "shinto" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
 			knora-base:listNodePosition 6 ;
-			rdfs:label "Shinto"@fr , "Shinto"@en .
+			rdfs:label "Shintoïste"@fr , "Shintoist"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-taoist> a knora-base:ListNode ;
 			knora-base:listNodeName "taoist" ;
@@ -6715,7 +6715,7 @@
 			knora-base:listNodeName "greek" ;
 			knora-base:hasRootNode <http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList> ;
 			knora-base:listNodePosition 8 ;
-			rdfs:label "Grecque (ancien)"@fr , "Greek"@en .
+			rdfs:label "Grec (ancien)"@fr , "Greek"@en .
 
 		<http://rdfh.ch/lists/drawings-gods-2016-list-DrawingReligiousIdentityList-egyptian> a knora-base:ListNode ;
 			knora-base:listNodeName "egyptian" ;


### PR DESCRIPTION
For both onthology and lists:
1. Corrected order of individual questionary. 2. Corrected temples, religions of Japan (collided with the rest). 3. Corrected plenty of typos. 4. Changed Labels of some objects Passage-Visit, Campagne-Reserach Wave, etc. (Marion, we might need to do it also in the owls-part, but I did not touch it.) Christelle will send complete list.
Marion, please use the numbers 1-9 for the label and other admin properties that I do not see directly for the individual questionary. There are 122 things to place by order so far, so I list them here:
1-9 - for admin of Marion, 
10- rel identity, 
11- 45 familiarity with temples, 
46-53 japan mixed (jinja-otera)
54-58 jinjia, i.e. shinto, 
59-61 objects at home japan, 
62-77 prayer,
78 -86 could you draw?...
87-96 location, age, sex of god, meaning of the word
97 -122 admin swiss

This can be merged already.

Remains from my side: new structure of keywords, to come next Tuesday.