### PR TITLE
Add missing salsah-gui:guiOrder

### DIFF
--- a/drawings-gods-ontology.ttl
+++ b/drawings-gods-ontology.ttl
@@ -3892,6 +3892,7 @@ drawings-gods:Drawing a owl:Class ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty drawings-gods:hasCollectionContext ],
         [ a owl:Restriction ;
+            salsah-gui:guiOrder 6 ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty drawings-gods:hasCollectionContextValue ],
         [ a owl:Restriction ;
@@ -4407,9 +4408,6 @@ drawings-gods:QuestionnaireIndividual a owl:Class ;
             salsah-gui:guiOrder 112 ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
             owl:onProperty drawings-gods:sexOfGodOther ],
-        [ a owl:Restriction ;
-            owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-            owl:onProperty drawings-gods:hasQuestionnaireUnavailable ],
         [ a owl:Restriction ;
             salsah-gui:guiOrder 115 ;
             owl:maxCardinality "1"^^xsd:nonNegativeInteger ;

--- a/drawings-gods-ontology.ttl
+++ b/drawings-gods-ontology.ttl
@@ -3973,6 +3973,10 @@ drawings-gods:QuestionnaireIndividual a owl:Class ;
     rdfs:label "Individual questionnaire"@en,
         "Questionnaire individuel"@fr ;
     rdfs:subClassOf [ a owl:Restriction ;
+            salsah-gui:guiOrder 0 ;
+            owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+            owl:onProperty drawings-gods:hasQuestionnaireUnavailable ],
+        [ a owl:Restriction ;
             salsah-gui:guiOrder 200 ;
             owl:minCardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty drawings-gods:hasQuestionnaireIndividualComment ],


### PR DESCRIPTION
Add missing salsah-gui:guiOrder
Delete a duplicate property for `QuestionnaireIndividual` (hasQuestionnaireUnavailable)


Closes #49 
Closes #50 